### PR TITLE
feat: standalone server + Docker image with queue auto-discovery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+**/dist
+.git
+.github
+.context
+screenshots
+*.log
+.DS_Store
+docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package.json yarn.lock tsconfig.base.json ./
+COPY packages/api/package.json packages/api/
+COPY packages/ui/package.json packages/ui/
+COPY packages/express/package.json packages/express/
+COPY packages/nestjs/package.json packages/nestjs/
+COPY packages/standalone/package.json packages/standalone/
+RUN yarn install --frozen-lockfile
+
+COPY . .
+RUN yarn workspace @aios-medical/bullmq-dashboard-api build \
+  && yarn workspace @aios-medical/bullmq-dashboard-ui build \
+  && yarn workspace @aios-medical/bullmq-dashboard-express build \
+  && yarn workspace @aios-medical/bullmq-dashboard-standalone build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package.json yarn.lock tsconfig.base.json ./
+COPY packages/api/package.json packages/api/
+COPY packages/ui/package.json packages/ui/
+COPY packages/express/package.json packages/express/
+COPY packages/nestjs/package.json packages/nestjs/
+COPY packages/standalone/package.json packages/standalone/
+RUN yarn install --frozen-lockfile --production && yarn cache clean
+
+COPY --from=builder /app/packages/api/dist packages/api/dist
+COPY --from=builder /app/packages/api/bullMQAdapter.js packages/api/bullMQAdapter.js
+COPY --from=builder /app/packages/api/bullAdapter.js packages/api/bullAdapter.js
+COPY --from=builder /app/packages/api/typings packages/api/typings
+COPY --from=builder /app/packages/express/dist packages/express/dist
+COPY --from=builder /app/packages/ui/dist packages/ui/dist
+COPY --from=builder /app/packages/standalone/dist packages/standalone/dist
+
+EXPOSE 3000
+USER node
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||3000)+'/healthz',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+
+CMD ["node", "packages/standalone/dist/cli.js"]

--- a/README.md
+++ b/README.md
@@ -49,9 +49,37 @@ opinionated UI without giving up the adapter ecosystem bull-board already built 
 | [`@aios-medical/bullmq-dashboard-ui`](https://www.npmjs.com/package/@aios-medical/bullmq-dashboard-ui)           | The new React UI. Ships as a static bundle (`dist/index.ejs` + `dist/static/`).  |
 | [`@aios-medical/bullmq-dashboard-express`](https://www.npmjs.com/package/@aios-medical/bullmq-dashboard-express) | Express server adapter.                                                          |
 | [`@aios-medical/bullmq-dashboard-nestjs`](https://www.npmjs.com/package/@aios-medical/bullmq-dashboard-nestjs)   | NestJS module (works with `@nestjs/bull` and `@nestjs/bullmq`).                  |
+| [`@aios-medical/bullmq-dashboard-standalone`](https://www.npmjs.com/package/@aios-medical/bullmq-dashboard-standalone) | Standalone server + Docker image. Connects to Redis and auto-discovers queues.   |
 
 Both **legacy Bull v4** and **BullMQ v5** are supported through
 `BullAdapter` and `BullMQAdapter` respectively.
+
+---
+
+## Standalone / Docker (no code changes)
+
+Don't want to wire the dashboard into your app? Run it as its own service. It
+connects to Redis, **auto-discovers your BullMQ queues**, and serves the same UI
+with no adapters and no redeploy, and it works with any app in any language.
+
+```bash
+docker run -p 3000:3000 -e REDIS_URL=redis://your-redis:6379 \
+  ghcr.io/fellahealth/bullmq-dashboard
+```
+
+Open http://localhost:3000. Or try the demo stack (Redis + dashboard + a job
+seeder so there's data to look at):
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+Configure via env vars (`REDIS_URL`, `BASIC_AUTH_USERNAME`/`BASIC_AUTH_PASSWORD`,
+`READ_ONLY`, `BASE_PATH`, `QUEUE_NAMES`, …). See the
+[standalone package README](./packages/standalone/README.md) for the full list.
+
+> Scope: standalone auto-discovery targets **BullMQ v5** on a single-node Redis.
+> For legacy Bull v4, use the embedded Express / NestJS adapters above.
 
 ---
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  dashboard:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: bullmq-dashboard
+    ports:
+      - '3000:3000'
+    environment:
+      REDIS_URL: redis://redis:6379
+      DASHBOARD_TITLE: BullMQ Dashboard (demo)
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  seeder:
+    image: bullmq-dashboard
+    working_dir: /app
+    volumes:
+      - ./seed.mjs:/app/seed.mjs:ro
+    environment:
+      REDIS_URL: redis://redis:6379
+    command: ['node', 'seed.mjs']
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped

--- a/docker/seed.mjs
+++ b/docker/seed.mjs
@@ -1,0 +1,46 @@
+import { Queue, Worker } from 'bullmq';
+
+const url = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+const connection = { url };
+
+const QUEUES = ['emails', 'reports', 'image-processing', 'webhooks'];
+const queues = Object.fromEntries(QUEUES.map((name) => [name, new Queue(name, { connection })]));
+
+const workers = QUEUES.map(
+  (name) =>
+    new Worker(
+      name,
+      async (job) => {
+        await new Promise((r) => setTimeout(r, 500 + Math.floor(job.timestamp % 2000)));
+        if (job.data.shouldFail) throw new Error('Simulated processing failure');
+        return { ok: true };
+      },
+      { connection, concurrency: 2 }
+    )
+);
+
+let n = 0;
+async function tick() {
+  n += 1;
+  const name = QUEUES[n % QUEUES.length];
+  const shouldFail = n % 5 === 0;
+  const delay = n % 7 === 0 ? 15000 : 0;
+  await queues[name].add(
+    `job-${n}`,
+    { seq: n, shouldFail, at: `t+${n}` },
+    { delay, attempts: 2, removeOnComplete: 50, removeOnFail: 50 }
+  );
+}
+
+console.log(`Seeding demo jobs into ${url} across: ${QUEUES.join(', ')}`);
+setInterval(() => {
+  tick().catch((e) => console.error('seed tick failed:', e.message));
+}, 1200);
+
+const shutdown = async () => {
+  await Promise.all(workers.map((w) => w.close().catch(() => {})));
+  await Promise.all(Object.values(queues).map((q) => q.close().catch(() => {})));
+  process.exit(0);
+};
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "workspaces": [
     "packages/*"
   ],
+  "resolutions": {
+    "ioredis": "5.10.1"
+  },
   "scripts": {
     "build": "yarn workspaces run build",
     "dev:ui": "yarn workspace @aios-medical/bullmq-dashboard-ui dev",

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -1,0 +1,87 @@
+# @aios-medical/bullmq-dashboard-standalone
+
+Run the BullMQ dashboard as its own service. Point it at a Redis instance and it
+**auto-discovers your queues**: no code changes, no adapters to wire up, no
+redeploy of your app.
+
+Unlike the embedded packages (Express / NestJS), where you construct `Queue`
+objects and register them in your app, the standalone server connects directly
+to Redis, scans for BullMQ queues, and serves the same dashboard UI. It works
+with any app in any language that writes BullMQ-compatible queues to Redis.
+
+## Quick start (Docker)
+
+```bash
+docker run -p 3000:3000 -e REDIS_URL=redis://your-redis:6379 \
+  ghcr.io/fellahealth/bullmq-dashboard
+```
+
+Open http://localhost:3000. Queues appear as soon as your app has produced jobs.
+
+### Try it with the demo stack
+
+From the repo root:
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+This starts Redis, the dashboard, and a seeder that drips fake jobs into a few
+queues so the dashboard has something to show immediately.
+
+## Quick start (Node)
+
+```bash
+yarn add @aios-medical/bullmq-dashboard-standalone
+REDIS_URL=redis://localhost:6379 npx bullmq-dashboard
+```
+
+Or programmatically:
+
+```ts
+import { loadConfig, startServer } from '@aios-medical/bullmq-dashboard-standalone';
+
+const { close } = await startServer(loadConfig());
+```
+
+## Configuration (environment variables)
+
+| Variable                | Default       | Description                                                             |
+| ----------------------- | ------------- | ----------------------------------------------------------------------- |
+| `REDIS_URL`             | -             | `redis://` / `rediss://` connection string. Takes precedence.           |
+| `REDIS_HOST`            | `127.0.0.1`   | Used when `REDIS_URL` is not set.                                       |
+| `REDIS_PORT`            | `6379`        |                                                                         |
+| `REDIS_USERNAME`        | -             |                                                                         |
+| `REDIS_PASSWORD`        | -             |                                                                         |
+| `REDIS_DB`              | `0`           |                                                                         |
+| `REDIS_TLS`             | `false`       | Set to `true` to connect over TLS.                                     |
+| `BULL_PREFIX`           | `bull`        | BullMQ key prefix to scan under.                                        |
+| `QUEUE_NAMES`           | -             | Comma-separated explicit list. Disables auto-discovery when set.        |
+| `DISCOVERY_INTERVAL_MS` | `15000`       | How often to re-scan Redis for new/removed queues. `0` disables.        |
+| `PORT`                  | `3000`        | HTTP port.                                                              |
+| `HOST`                  | `0.0.0.0`     | Bind address.                                                           |
+| `BASE_PATH`             | -             | Serve under a sub-path, e.g. `/admin/queues`.                           |
+| `READ_ONLY`             | `false`       | Disable all mutating actions (retry, pause, clean, add, …).             |
+| `BASIC_AUTH_USERNAME`   | -             | Enable HTTP basic auth (both username and password required).           |
+| `BASIC_AUTH_PASSWORD`   | -             |                                                                         |
+| `DASHBOARD_TITLE`       | `BullMQ Dashboard` | Title shown in the UI.                                              |
+| `DASHBOARD_SUBTITLE`    | -             | Optional subtitle.                                                      |
+
+## How discovery works
+
+BullMQ stores every queue under keys like `bull:<name>:meta` and `bull:<name>:id`.
+The server uses non-blocking `SCAN` (never `KEYS`) to find those structural keys,
+extracts the queue names, and builds an adapter per queue. It re-scans on an
+interval, so queues created after startup show up automatically.
+
+If `SCAN` is restricted on your Redis, set `QUEUE_NAMES` to list queues explicitly.
+
+## Health check
+
+`GET /healthz` returns `200` when Redis is connected, `503` otherwise. The Docker
+image has a built-in `HEALTHCHECK` using this endpoint.
+
+## Scope / limitations
+
+- Targets **BullMQ v5** and a **single-node Redis** (not Redis Cluster).
+- Legacy Bull v4 auto-discovery is not supported; use the embedded adapters for that.

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@aios-medical/bullmq-dashboard-standalone",
+  "version": "1.0.0",
+  "description": "Standalone BullMQ dashboard server. Point it at a Redis instance and it auto-discovers your queues, with no code changes and no redeploy.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fellahealth/bullmq-dashboard.git",
+    "directory": "packages/standalone"
+  },
+  "homepage": "https://github.com/fellahealth/bullmq-dashboard#readme",
+  "bugs": {
+    "url": "https://github.com/fellahealth/bullmq-dashboard/issues"
+  },
+  "keywords": [
+    "bull",
+    "bullmq",
+    "redis",
+    "queue",
+    "monitoring",
+    "dashboard",
+    "standalone",
+    "docker",
+    "aios"
+  ],
+  "license": "MIT",
+  "main": "dist/index.js",
+  "bin": {
+    "bullmq-dashboard": "dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "yarn clean && tsc",
+    "clean": "rm -rf dist",
+    "start": "node dist/cli.js",
+    "dev": "tsc && node dist/cli.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@aios-medical/bullmq-dashboard-api": "^1.0.0",
+    "@aios-medical/bullmq-dashboard-express": "^1.0.0",
+    "@aios-medical/bullmq-dashboard-ui": "^1.0.0",
+    "bullmq": "^5.78.1",
+    "express": "^4.21.2",
+    "express-basic-auth": "^1.2.1",
+    "ioredis": "^5.4.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/standalone/src/cli.ts
+++ b/packages/standalone/src/cli.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { loadConfig } from './config';
+import { startServer } from './server';
+
+async function main() {
+  const config = loadConfig();
+  const { close } = await startServer(config);
+
+  const url = `http://${config.host === '0.0.0.0' ? 'localhost' : config.host}:${config.port}${config.basePath}`;
+  console.log(`BullMQ dashboard listening on ${url}`);
+  if (config.readOnly) {
+    console.log('Running in READ-ONLY mode. Mutating actions are disabled.');
+  }
+
+  const shutdown = (signal: string) => {
+    console.log(`\nReceived ${signal}, shutting down…`);
+    close()
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1));
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+main().catch((err) => {
+  console.error('Failed to start BullMQ dashboard:', err);
+  process.exit(1);
+});

--- a/packages/standalone/src/config.ts
+++ b/packages/standalone/src/config.ts
@@ -1,0 +1,79 @@
+import type { RedisOptions } from 'ioredis';
+
+export interface StandaloneConfig {
+  port: number;
+  host: string;
+  basePath: string;
+
+  redis: { url: string } | RedisOptions;
+  bullPrefix: string;
+
+  queueNames: string[] | null;
+  discoveryIntervalMs: number;
+
+  readOnly: boolean;
+
+  basicAuth: { username: string; password: string } | null;
+
+  title: string;
+  subtitle: string | undefined;
+}
+
+function bool(value: string | undefined, fallback = false): boolean {
+  if (value === undefined) return fallback;
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function int(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === '') return fallback;
+  const n = Number.parseInt(value, 10);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): StandaloneConfig {
+  let redis: StandaloneConfig['redis'];
+  if (env.REDIS_URL && env.REDIS_URL.trim() !== '') {
+    redis = { url: env.REDIS_URL.trim() };
+  } else {
+    const options: RedisOptions = {
+      host: env.REDIS_HOST || '127.0.0.1',
+      port: int(env.REDIS_PORT, 6379),
+      db: int(env.REDIS_DB, 0),
+    };
+    if (env.REDIS_USERNAME) options.username = env.REDIS_USERNAME;
+    if (env.REDIS_PASSWORD) options.password = env.REDIS_PASSWORD;
+    if (bool(env.REDIS_TLS)) options.tls = {};
+    redis = options;
+  }
+
+  const basicAuth =
+    env.BASIC_AUTH_USERNAME && env.BASIC_AUTH_PASSWORD
+      ? { username: env.BASIC_AUTH_USERNAME, password: env.BASIC_AUTH_PASSWORD }
+      : null;
+
+  const queueNames =
+    env.QUEUE_NAMES && env.QUEUE_NAMES.trim() !== ''
+      ? env.QUEUE_NAMES.split(',')
+          .map((name) => name.trim())
+          .filter(Boolean)
+      : null;
+
+  return {
+    port: int(env.PORT, 3000),
+    host: env.HOST || '0.0.0.0',
+    basePath: env.BASE_PATH || '',
+
+    redis,
+    bullPrefix: env.BULL_PREFIX || 'bull',
+
+    queueNames,
+    discoveryIntervalMs: int(env.DISCOVERY_INTERVAL_MS, 15000),
+
+    readOnly: bool(env.READ_ONLY),
+
+    basicAuth,
+
+    title: env.DASHBOARD_TITLE || 'BullMQ Dashboard',
+    subtitle: env.DASHBOARD_SUBTITLE || undefined,
+  };
+}

--- a/packages/standalone/src/discovery.ts
+++ b/packages/standalone/src/discovery.ts
@@ -1,0 +1,74 @@
+import { Queue } from 'bullmq';
+import type { Redis } from 'ioredis';
+import { BullMQAdapter } from '@aios-medical/bullmq-dashboard-api/bullMQAdapter';
+
+import type { StandaloneConfig } from './config';
+
+const QUEUE_KEY_SUFFIXES = ['meta', 'id'] as const;
+
+export async function discoverQueueNames(client: Redis, prefix: string): Promise<string[]> {
+  const names = new Set<string>();
+
+  for (const suffix of QUEUE_KEY_SUFFIXES) {
+    const pattern = `${prefix}:*:${suffix}`;
+    let cursor = '0';
+    do {
+      const [next, keys] = await client.scan(cursor, 'MATCH', pattern, 'COUNT', 1000);
+      cursor = next;
+      for (const key of keys) {
+        const name = key.slice(prefix.length + 1, key.length - suffix.length - 1);
+        if (name) names.add(name);
+      }
+    } while (cursor !== '0');
+  }
+
+  return [...names].sort();
+}
+
+export interface QueueRegistryApi {
+  addQueue: (queue: BullMQAdapter) => void;
+  removeQueue: (queueOrName: string | BullMQAdapter) => void;
+}
+
+export class QueueDiscovery {
+  private readonly known = new Map<string, Queue>();
+
+  constructor(
+    private readonly client: Redis,
+    private readonly config: StandaloneConfig,
+    private readonly registry: QueueRegistryApi
+  ) {}
+
+  private async resolveNames(): Promise<string[]> {
+    if (this.config.queueNames) return this.config.queueNames;
+    return discoverQueueNames(this.client, this.config.bullPrefix);
+  }
+
+  async reconcile(): Promise<string[]> {
+    const names = await this.resolveNames();
+    const current = new Set(names);
+
+    for (const name of names) {
+      if (this.known.has(name)) continue;
+      const queue = new Queue(name, { connection: this.client, prefix: this.config.bullPrefix });
+      this.known.set(name, queue);
+      this.registry.addQueue(new BullMQAdapter(queue, { readOnlyMode: this.config.readOnly }));
+    }
+
+    if (!this.config.queueNames) {
+      for (const [name, queue] of this.known) {
+        if (current.has(name)) continue;
+        this.registry.removeQueue(name);
+        this.known.delete(name);
+        void queue.close().catch(() => undefined);
+      }
+    }
+
+    return names;
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([...this.known.values()].map((q) => q.close().catch(() => undefined)));
+    this.known.clear();
+  }
+}

--- a/packages/standalone/src/discovery.ts
+++ b/packages/standalone/src/discovery.ts
@@ -1,4 +1,5 @@
 import { Queue } from 'bullmq';
+import type { ConnectionOptions } from 'bullmq';
 import type { Redis } from 'ioredis';
 import { BullMQAdapter } from '@aios-medical/bullmq-dashboard-api/bullMQAdapter';
 
@@ -36,7 +37,8 @@ export class QueueDiscovery {
   constructor(
     private readonly client: Redis,
     private readonly config: StandaloneConfig,
-    private readonly registry: QueueRegistryApi
+    private readonly registry: QueueRegistryApi,
+    private readonly queueConnection: ConnectionOptions
   ) {}
 
   private async resolveNames(): Promise<string[]> {
@@ -50,7 +52,10 @@ export class QueueDiscovery {
 
     for (const name of names) {
       if (this.known.has(name)) continue;
-      const queue = new Queue(name, { connection: this.client, prefix: this.config.bullPrefix });
+      const queue = new Queue(name, {
+        connection: this.queueConnection,
+        prefix: this.config.bullPrefix,
+      });
       this.known.set(name, queue);
       this.registry.addQueue(new BullMQAdapter(queue, { readOnlyMode: this.config.readOnly }));
     }

--- a/packages/standalone/src/index.ts
+++ b/packages/standalone/src/index.ts
@@ -1,0 +1,5 @@
+export { loadConfig } from './config';
+export type { StandaloneConfig } from './config';
+export { startServer } from './server';
+export type { StandaloneServer } from './server';
+export { QueueDiscovery, discoverQueueNames } from './discovery';

--- a/packages/standalone/src/server.ts
+++ b/packages/standalone/src/server.ts
@@ -1,0 +1,99 @@
+import type { Server } from 'http';
+import express from 'express';
+import basicAuth from 'express-basic-auth';
+import IORedis, { type Redis } from 'ioredis';
+import { createDashboard } from '@aios-medical/bullmq-dashboard-api';
+import { ExpressAdapter } from '@aios-medical/bullmq-dashboard-express';
+
+import type { StandaloneConfig } from './config';
+import { QueueDiscovery } from './discovery';
+
+export interface StandaloneServer {
+  server: Server;
+  redis: Redis;
+  discovery: QueueDiscovery;
+  close: () => Promise<void>;
+}
+
+function createRedis(config: StandaloneConfig): Redis {
+  if ('url' in config.redis) {
+    return new IORedis(config.redis.url, { maxRetriesPerRequest: null });
+  }
+  return new IORedis({ ...config.redis, maxRetriesPerRequest: null });
+}
+
+export async function startServer(config: StandaloneConfig): Promise<StandaloneServer> {
+  const redis = createRedis(config);
+
+  const serverAdapter = new ExpressAdapter();
+  if (config.basePath) {
+    serverAdapter.setBasePath(config.basePath);
+  }
+  const { addQueue, removeQueue } = createDashboard({
+    queues: [],
+    serverAdapter,
+    options: {
+      uiConfig: {
+        title: config.title,
+        ...(config.subtitle ? { subtitle: config.subtitle } : {}),
+      },
+    },
+  });
+
+  const discovery = new QueueDiscovery(redis, config, { addQueue, removeQueue });
+
+  const initialNames = await discovery.reconcile();
+  console.log(
+    initialNames.length > 0
+      ? `Discovered ${initialNames.length} queue(s): ${initialNames.join(', ')}`
+      : 'No queues found yet. They will appear here as soon as your app produces jobs.'
+  );
+
+  let refreshTimer: NodeJS.Timeout | undefined;
+  if (!config.queueNames && config.discoveryIntervalMs > 0) {
+    refreshTimer = setInterval(() => {
+      discovery.reconcile().catch((err) => {
+        console.error('Queue discovery refresh failed:', err?.message ?? err);
+      });
+    }, config.discoveryIntervalMs);
+    refreshTimer.unref();
+  }
+
+  const app = express();
+
+  app.get('/healthz', (_req, res) => {
+    res.status(redis.status === 'ready' ? 200 : 503).json({
+      status: redis.status === 'ready' ? 'ok' : 'degraded',
+      redis: redis.status,
+    });
+  });
+
+  if (config.basicAuth) {
+    app.use(
+      basicAuth({
+        challenge: true,
+        users: { [config.basicAuth.username]: config.basicAuth.password },
+      })
+    );
+  }
+
+  const router = serverAdapter.getRouter();
+  if (config.basePath) {
+    app.use(config.basePath, router);
+  } else {
+    app.use(router);
+  }
+
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(config.port, config.host, () => resolve(s));
+  });
+
+  const close = async () => {
+    if (refreshTimer) clearInterval(refreshTimer);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await discovery.close();
+    await redis.quit().catch(() => redis.disconnect());
+  };
+
+  return { server, redis, discovery, close };
+}

--- a/packages/standalone/src/server.ts
+++ b/packages/standalone/src/server.ts
@@ -2,6 +2,7 @@ import type { Server } from 'http';
 import express from 'express';
 import basicAuth from 'express-basic-auth';
 import IORedis, { type Redis } from 'ioredis';
+import type { ConnectionOptions } from 'bullmq';
 import { createDashboard } from '@aios-medical/bullmq-dashboard-api';
 import { ExpressAdapter } from '@aios-medical/bullmq-dashboard-express';
 
@@ -22,6 +23,13 @@ function createRedis(config: StandaloneConfig): Redis {
   return new IORedis({ ...config.redis, maxRetriesPerRequest: null });
 }
 
+function queueConnection(config: StandaloneConfig): ConnectionOptions {
+  if ('url' in config.redis) {
+    return { url: config.redis.url, maxRetriesPerRequest: null } as ConnectionOptions;
+  }
+  return { ...config.redis, maxRetriesPerRequest: null } as ConnectionOptions;
+}
+
 export async function startServer(config: StandaloneConfig): Promise<StandaloneServer> {
   const redis = createRedis(config);
 
@@ -40,7 +48,7 @@ export async function startServer(config: StandaloneConfig): Promise<StandaloneS
     },
   });
 
-  const discovery = new QueueDiscovery(redis, config, { addQueue, removeQueue });
+  const discovery = new QueueDiscovery(redis, config, { addQueue, removeQueue }, queueConnection(config));
 
   const initialNames = await discovery.reconcile();
   console.log(

--- a/packages/standalone/tsconfig.json
+++ b/packages/standalone/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "CommonJS",
+    "types": ["node"]
+  },
+  "include": ["./src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,6 +1174,13 @@
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
 
+"@types/node@^22.10.0":
+  version "22.20.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
+  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/node@^22.10.5":
   version "22.19.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.19.tgz#3124bf26ded54168b768138321fef99b420c6112"
@@ -1291,6 +1298,13 @@ baseline-browser-mapping@^2.10.12:
   version "2.10.32"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz#b6b553a4285fdd606327a617de36a5351e3aaa64"
   integrity sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==
+
+basic-auth@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 body-parser@~1.20.5:
   version "1.20.5"
@@ -1691,6 +1705,13 @@ eventemitter3@^4.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+express-basic-auth@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/express-basic-auth/-/express-basic-auth-1.2.1.tgz#d31241c03a915dd55db7e5285573049cfcc36381"
+  integrity sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==
+  dependencies:
+    basic-auth "^2.0.1"
+
 express@^4.21.2:
   version "4.22.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.22.2.tgz#c17ae0981e5efc24b22272f0e041c4662503b700"
@@ -1918,7 +1939,7 @@ inherits@~2.0.4:
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
-ioredis@5.10.1, ioredis@^5.3.2:
+ioredis@5.10.1, ioredis@^5.3.2, ioredis@^5.4.1:
   version "5.10.1"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.10.1.tgz#6082781d8aec8d51ee4936bf81d0610404db1e3d"
   integrity sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==
@@ -2493,6 +2514,11 @@ rxjs@^7.8.2:
   integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
     tslib "^2.1.0"
+
+safe-buffer@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-buffer@5.2.1:
   version "5.2.1"


### PR DESCRIPTION
## What & why

Adds **`@aios-medical/bullmq-dashboard-standalone`**: run the dashboard as its own service instead of embedding it in your app. It connects to Redis, **auto-discovers your BullMQ queues** (non-blocking `SCAN`), and serves the existing UI. No code changes, no adapters to wire up, no redeploy of the host app; works with any app in any language that writes BullMQ queues to Redis.

```bash
docker run -p 3000:3000 -e REDIS_URL=redis://your-redis:6379 ghcr.io/fellahealth/bullmq-dashboard
```

Or try the demo stack (Redis + dashboard + job seeder):

```bash
docker compose -f docker/docker-compose.yml up --build
```

## Changes

- **`packages/standalone/`**: env-var config, Redis scan + reconcile loop, server wiring, CLI, README
- **`Dockerfile`**: multi-stage, production deps only (~262 MB), built-in `HEALTHCHECK`
- **`docker/docker-compose.yml` + `docker/seed.mjs`**: 30-second demo stack
- Root `README.md`: new "Standalone / Docker" section
- `package.json`: pin `ioredis` via `resolutions` so the shared BullMQ connection type resolves

## Config (env vars)

`REDIS_URL` (or discrete host/port/password/db/TLS), `BULL_PREFIX`, `QUEUE_NAMES` (explicit override), `DISCOVERY_INTERVAL_MS`, `READ_ONLY`, `BASIC_AUTH_USERNAME`/`PASSWORD`, `BASE_PATH`, `PORT`, `DASHBOARD_TITLE`/`SUBTITLE`.

## Verified end-to-end (real Redis + real Docker)

- ✅ Discovery of seeded queues with correct job counts
- ✅ Runtime discovery: a queue created *after* boot appears automatically
- ✅ Basic auth (401 without creds to 200 with)
- ✅ Read-only mode reflected in adapters (`allowRetries: false`)
- ✅ Sub-path mount (`BASE_PATH=/admin/queues`): `<base href>` + API resolve, `/healthz` stays at root
- ✅ Full `docker compose` stack healthy with live completed/failed/active/delayed states

## Scope

v1 targets **BullMQ v5 on single-node Redis**. Legacy Bull v4 auto-discovery and Redis Cluster are out of scope; the embedded Express/NestJS adapters still cover Bull v4.
