### PR TITLE
feat: dashboard-wide read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,40 @@ ignored and the UI displays a banner explaining the server-side override.
 
 ---
 
+## Read-only mode
+
+Pass `readOnlyMode: true` at the top level of the dashboard options (alongside `uiConfig`, not
+inside it) to turn the whole dashboard into a viewer. The server rejects every mutating request
+with `405 Method Not Allowed`, and the UI hides all action controls (retry, promote, remove,
+pause/resume, clean, add job). Read endpoints (queues, jobs, logs, search) keep working.
+
+```ts
+createDashboard({
+  queues,
+  serverAdapter,
+  options: {
+    readOnlyMode: true,
+    uiConfig: { title: 'My Queues (read-only)' },
+  },
+});
+```
+
+For NestJS, set it inside `dashboardOptions`:
+
+```ts
+AIOSBullMQDashboardModule.forRoot({
+  route: '/queues',
+  adapter: ExpressAdapter,
+  dashboardOptions: { readOnlyMode: true },
+});
+```
+
+The flag applies to **every** queue, including queues registered later at runtime, and takes
+precedence over per-queue `readOnlyMode` options. Enforcement is server-side, so it holds even
+if a client is modified to re-enable the buttons.
+
+---
+
 ## Local development
 
 The repo is a yarn workspace. To work on the packages:

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,7 +14,25 @@ export function createDashboard({
   serverAdapter: IServerAdapter;
   options?: DashboardOptions;
 }) {
-  const { queueRegistry, setQueues, replaceQueues, addQueue, removeQueue } = getQueuesApi(queues);
+  const readOnlyMode = options.readOnlyMode === true;
+  const base = getQueuesApi(queues);
+  const { queueRegistry, removeQueue } = base;
+
+  // When the dashboard is read-only, force every queue (current and any added
+  // later, e.g. via runtime discovery) into read-only so the server rejects
+  // mutations and the UI hides the corresponding actions.
+  const enforce = (queue: BaseAdapter): BaseAdapter => {
+    if (readOnlyMode) queue.enableReadOnlyMode();
+    return queue;
+  };
+  if (readOnlyMode) queueRegistry.forEach((queue) => queue.enableReadOnlyMode());
+
+  const addQueue = (queue: BaseAdapter) => base.addQueue(enforce(queue));
+  const setQueues = (newQueues: ReadonlyArray<BaseAdapter>) =>
+    base.setQueues(newQueues.map(enforce));
+  const replaceQueues = (newQueues: ReadonlyArray<BaseAdapter>) =>
+    base.replaceQueues(newQueues.map(enforce));
+
   const uiBasePath =
     options.uiBasePath ||
     // oxlint-disable-next-line no-eval
@@ -31,6 +49,7 @@ export function createDashboard({
         alternative: 'static/favicon-32x32.png',
       },
       ...options.uiConfig,
+      ...(readOnlyMode ? { readOnlyMode: true } : {}),
     })
     .setEntryRoute(appRoutes.entryPoint)
     .setErrorHandler(errorHandler)

--- a/packages/api/src/queueAdapters/base.ts
+++ b/packages/api/src/queueAdapters/base.ts
@@ -12,9 +12,9 @@ import {
 } from '../../typings/app';
 
 export abstract class BaseAdapter {
-  public readonly readOnlyMode: boolean;
-  public readonly allowRetries: boolean;
-  public readonly allowCompletedRetries: boolean;
+  public readOnlyMode: boolean;
+  public allowRetries: boolean;
+  public allowCompletedRetries: boolean;
   public readonly prefix: string;
   public readonly delimiter: string;
   public readonly description: string;
@@ -37,6 +37,12 @@ export abstract class BaseAdapter {
     this.displayName = options.displayName || '';
     this.type = type;
     this.externalJobUrl = options.externalJobUrl;
+  }
+
+  public enableReadOnlyMode(): void {
+    this.readOnlyMode = true;
+    this.allowRetries = false;
+    this.allowCompletedRetries = false;
   }
 
   public getDescription(): string {

--- a/packages/api/typings/app.d.ts
+++ b/packages/api/typings/app.d.ts
@@ -245,6 +245,7 @@ export type FormatterField = 'data' | 'returnValue' | 'name' | 'progress';
 export type DashboardOptions = {
   uiBasePath?: string;
   uiConfig?: UIConfig;
+  readOnlyMode?: boolean;
 };
 
 export type IMiscLink = {
@@ -253,6 +254,7 @@ export type IMiscLink = {
 };
 
 export type UIConfig = Partial<{
+  readOnlyMode: boolean;
   title: string;
   subtitle: string;
   logo: { path: string; width?: number | string; height?: number | string };

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -86,6 +86,7 @@ export interface RedisStats {
 }
 
 export interface UIConfig {
+  readOnlyMode?: boolean;
   title?: string;
   subtitle?: string;
   pollingInterval?: { showSetting?: boolean; forceInterval?: number };

--- a/packages/ui/src/pages/JobPage.tsx
+++ b/packages/ui/src/pages/JobPage.tsx
@@ -15,6 +15,7 @@ import {
 import { useJob, useJobLogs } from '../hooks/useQueues';
 import { useConfirm } from '../hooks/useConfirm';
 import { api } from '../lib/api';
+import { uiConfig } from '../lib/uiConfig';
 import { Card, CardBody, CardHeader } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Badge } from '../components/ui/Badge';
@@ -136,19 +137,21 @@ export default function JobPage() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        <Button variant="secondary" size="sm" onClick={handleRetry}>
-          <RotateCcw className="h-3.5 w-3.5" /> Retry
-        </Button>
-        {status === 'delayed' && (
-          <Button variant="secondary" size="sm" onClick={handlePromote}>
-            <ChevronsUp className="h-3.5 w-3.5" /> Promote
+      {!uiConfig.readOnlyMode && (
+        <div className="flex flex-wrap gap-2">
+          <Button variant="secondary" size="sm" onClick={handleRetry}>
+            <RotateCcw className="h-3.5 w-3.5" /> Retry
           </Button>
-        )}
-        <Button variant="outline" size="sm" onClick={handleRemove}>
-          <Trash2 className="h-3.5 w-3.5" /> Remove
-        </Button>
-      </div>
+          {status === 'delayed' && (
+            <Button variant="secondary" size="sm" onClick={handlePromote}>
+              <ChevronsUp className="h-3.5 w-3.5" /> Promote
+            </Button>
+          )}
+          <Button variant="outline" size="sm" onClick={handleRemove}>
+            <Trash2 className="h-3.5 w-3.5" /> Remove
+          </Button>
+        </div>
+      )}
 
       <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <MetricTile icon={<Clock className="h-3.5 w-3.5" />} label="Created" value={formatRelative(job.timestamp)} hint={formatAbsolute(job.timestamp)} />


### PR DESCRIPTION
## What & why

Adds a top-level `readOnlyMode` option to `createDashboard` (and NestJS `dashboardOptions`) that turns the entire dashboard into a viewer. Frequently requested for production dashboards where you want visibility without the risk of someone retrying/removing/pausing a queue.

```ts
createDashboard({
  queues,
  serverAdapter,
  options: {
    readOnlyMode: true,
    uiConfig: { title: 'My Queues (read-only)' },
  },
});
```

NestJS:

```ts
AIOSBullMQDashboardModule.forRoot({
  route: '/queues',
  adapter: ExpressAdapter,
  dashboardOptions: { readOnlyMode: true },
});
```

## How it works

- **Server-side enforcement.** The existing per-queue `queueProvider` guard already returns `405` for mutating routes on read-only queues. The new option forces every queue into read-only, so the guard covers the whole dashboard. Enforcement holds even if a client is modified to re-enable buttons.
- **Applies to runtime-added queues.** `createDashboard` wraps `addQueue`/`setQueues`/`replaceQueues`, so queues registered after boot (e.g. via discovery) are also forced read-only. Overrides per-queue `readOnlyMode`.
- **UI gating.** The flag is injected into `uiConfig`; `JobPage` actions are now gated on it (`QueuePage` was already gated per queue via `queue.readOnlyMode`). Read views (queues, jobs, logs, search) are unaffected.
- `BaseAdapter` gains `enableReadOnlyMode()`; the `readOnlyMode` / `allowRetries` / `allowCompletedRetries` fields are now mutable so the flag can be applied after construction (kept public, so cross-package structural typing is preserved).
